### PR TITLE
fix: use `jwt-decode` to decode at client side

### DIFF
--- a/packages/unicourse/package.json
+++ b/packages/unicourse/package.json
@@ -21,6 +21,7 @@
         "course-pack": "workspace:*",
         "cross-fetch": "^3.1.5",
         "debug": "^4.3.4",
+        "jwt-decode": "^3.1.2",
         "zod": "^3.19.1"
     },
     "devDependencies": {

--- a/packages/unicourse/src/unicourse.ts
+++ b/packages/unicourse/src/unicourse.ts
@@ -1,7 +1,7 @@
 import fetch from "cross-fetch";
 import debug from "debug";
 import type { Token } from "@unicourse-tw/token";
-import { decode } from "@unicourse-tw/token";
+import decode from "jwt-decode";
 import type { CoursePack } from "course-pack";
 import { verify as verify_course_pack } from "course-pack";
 import { hash } from "./hash";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,7 @@ importers:
       course-pack: workspace:*
       cross-fetch: ^3.1.5
       debug: ^4.3.4
+      jwt-decode: ^3.1.2
       tsup: ^6.4.0
       typedoc: ^0.23.20
       typescript: ^4.8.4
@@ -177,6 +178,7 @@ importers:
       course-pack: link:../course-pack
       cross-fetch: 3.1.5
       debug: 4.3.4
+      jwt-decode: 3.1.2
       zod: 3.19.1
     devDependencies:
       '@types/debug': 4.1.7
@@ -4219,6 +4221,10 @@ packages:
     dependencies:
       jwa: 1.4.1
       safe-buffer: 5.2.1
+    dev: false
+
+  /jwt-decode/3.1.2:
+    resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
     dev: false
 
   /keygrip/1.1.0:


### PR DESCRIPTION
`jsonwebtoken` doesn't support browser environment, replaced with `jwt-decode` on client side.