### PR TITLE
ci: load build args by action input

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -51,5 +51,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-        env:
-          GIT_COMMIT: ${{ github.sha }}
+          build-args: GIT_COMMIT=${{ github.sha }}


### PR DESCRIPTION
It seems that the `docker/build-push-action` action doesn't respect my `docker-compose.yml`. I think it is because it directly calls `docker buildx build` (I use `docker compose build` on my machine) and only loads some parts of the compose file.

As a solution, I simply set the commit hash as a build argument by the action input.
