### PR TITLE
feat: add user id to token

### DIFF
--- a/packages/token/src/decode.ts
+++ b/packages/token/src/decode.ts
@@ -4,13 +4,15 @@ import type { Token } from "./types";
 export function decode(token: string): Token {
     const result = jwt.decode(token) as {
         user: string
+        username: string
         traits: string[]
         exp: number
         jti: string
     };
 
     return {
-        username: result.user,
+        user: result.user,
+        username: result.username,
         traits: result.traits,
         expires: result.exp,
         token: result.jti

--- a/packages/token/src/sign.ts
+++ b/packages/token/src/sign.ts
@@ -15,7 +15,8 @@ export function sign(token: Token, options?: jwt.SignOptions): string {
     }
 
     return jwt.sign({
-        user: token.username,
+        user: token.user,
+        username: token.username,
         traits: token.traits
     }, process.env.JWT_SECRET ?? "unicourse", {
         expiresIn: exp,

--- a/packages/token/src/types.ts
+++ b/packages/token/src/types.ts
@@ -1,6 +1,8 @@
 export interface Token {
     /** Cuid of the token */
     token: string
+    /** Cuid of the owner */
+    user: string
     /** Owner of the token */
     username: string
     /** Expiration date number (in seconds) */

--- a/packages/token/src/verify.ts
+++ b/packages/token/src/verify.ts
@@ -4,13 +4,15 @@ import type { Token } from "./types";
 export function verify(token: string): Token {
     const result = jwt.verify(token, process.env.JWT_SECRET ?? "unicourse") as {
         user: string
+        username: string
         traits: string[]
         exp: number
         jti: string
     };
 
     return {
-        username: result.user,
+        user: result.user,
+        username: result.username,
         traits: result.traits,
         expires: result.exp,
         token: result.jti

--- a/packages/token/tests/sign.test.ts
+++ b/packages/token/tests/sign.test.ts
@@ -4,6 +4,7 @@ describe("sign", () => {
     test("accepted", () => {
         const token = {
             token: "cuid",
+            user: "cuid-user",
             username: "username",
             expires: Math.floor(Date.now() / 1_000) + 60,
             traits: ["trait"]
@@ -18,6 +19,7 @@ describe("sign", () => {
     test("expired", () => {
         const token = {
             token: "cuid",
+            user: "cuid-user",
             username: "username",
             expires: Math.floor(Date.now() / 1_000) - 1,
             traits: ["trait"]

--- a/packages/token/tests/sign.test.ts
+++ b/packages/token/tests/sign.test.ts
@@ -1,4 +1,4 @@
-import { decode, sign } from "../src";
+import { decode, sign, verify } from "../src";
 
 describe("sign", () => {
     test("accepted", () => {
@@ -26,5 +26,40 @@ describe("sign", () => {
         };
 
         expect(() => sign(token)).toThrow();
+    });
+
+    test("verify", () => {
+        const token = {
+            token: "cuid",
+            user: "cuid-user",
+            username: "username",
+            expires: Math.floor(Date.now() / 1_000) + 60,
+            traits: ["trait"]
+        };
+
+        const signed = sign(token);
+        const decoded = verify(signed);
+        expect(decoded).toEqual(token);
+    });
+
+    test("verify invalid", () => {
+        const token = {
+            token: "cuid",
+            user: "cuid-user",
+            username: "username",
+            expires: Math.floor(Date.now() / 1_000) + 60,
+            traits: ["trait"]
+        };
+
+        const signed = sign(token);
+
+        const parts = signed.split(".");
+        const payload = JSON.parse(Buffer.from(parts[1], "base64").toString());
+        payload.traits = ["invalid"];
+        const modified = [
+            parts[0], Buffer.from(JSON.stringify(payload)).toString("base64"), parts[2]
+        ].join(".");
+
+        expect(() => verify(modified)).toThrow();
     });
 });

--- a/packages/unicourse/src/unicourse.ts
+++ b/packages/unicourse/src/unicourse.ts
@@ -46,6 +46,7 @@ export class UniCourse {
         this._raw_token = token;
         const result = decode<{
             user: string
+            username: string
             traits: string[]
             iat: number
             exp: number
@@ -53,7 +54,8 @@ export class UniCourse {
         }>(token);
         this.token = {
             token: result.jti,
-            username: result.user,
+            user: result.user,
+            username: result.username,
             expires: result.exp,
             traits: result.traits
         };

--- a/src/api/auth/login.ts
+++ b/src/api/auth/login.ts
@@ -63,6 +63,7 @@ router.post("/login", async ctx => {
 
     const token: Token = {
         token: cuid(),
+        user: account.user_id,
         username: account.username,
         expires: Math.floor(Date.now() / 1000) + 60 * 60,
         traits: [...new Set([


### PR DESCRIPTION
This PR changed the JWT payload.

`user` is now the owner's user ID
`username` is now the owner's username

For the users of `@unicourse-tw/token`, this is not a breaking change, just a new property `user` has been added to the interface `Token`.

Resolve #28 