### PR TITLE
feat: client import options

### DIFF
--- a/packages/cli/src/commands/import.ts
+++ b/packages/cli/src/commands/import.ts
@@ -9,12 +9,16 @@ const command = new Command("import")
     .description("Import course pack from a JSON file")
     .argument("<file>", "File path")
     .option("-s, --server <server>", "The server to log in to", config.server || defaults.server)
+    .option(
+        "--scope <entity>",
+        "If specified, the importer will use scoped merge strategy with the given id"
+    )
     .action(async (file: string, opt) => {
         const uni = new UniCourse(config.token, { server: opt.server });
 
         try {
             const json = JSON.parse(fs.readFileSync(file, "utf8"));
-            const result = await uni.import(json);
+            const result = await uni.import(json, opt.scope);
             for (const [key, value] of Object.entries(result)) {
                 console.log(chalk.cyan.bold(key), value.join(", "));
             }

--- a/packages/unicourse/src/unicourse.ts
+++ b/packages/unicourse/src/unicourse.ts
@@ -195,13 +195,18 @@ export class UniCourse {
         return this.req(`profile/${username}`);
     }
 
+    /**
+     * @param json The `CoursePack` to import.
+     * @param scope If specified, the importer will use scoped merge strategy with the given id.
+     */
     public async import(
-        json: CoursePack
+        json: CoursePack,
+        scope?: string
     ): Promise<EndpointResponseBody<"manage/import", typeof POST>> {
         const packed = verify_course_pack(json);
         return this.req("manage/import", {
             method: "POST",
-            body: packed
+            body: { ...packed, scope }
         });
     }
 }


### PR DESCRIPTION
Hello @UniCourse-TW/backend,

I have made the following changes in this pull request:

- Add a second parameter to the `import` method of client library to specify an entity id when using scoped import strategy.
- Add an optional `--scope` flag to the command line interface, allowing users to specify the scoped root entity when running the CLI.

Please let me know if you have any questions or feedback.

Thank you.
