### PR TITLE
test(search): parse query

### DIFF
--- a/packages/search/src/parser.ts
+++ b/packages/search/src/parser.ts
@@ -15,7 +15,15 @@ export function parse_query(q: string): Record<string, string[]> {
     const result: Record<string, string[]> = {};
 
     for (const match of matches) {
-        if (/[=:]/.test(match)) {
+        if (/^["\s]/.test(match) && /["\s]$/.test(match)) {
+            const stripped = match.replace(/^["\s]|["\s]$/g, "");
+
+            if ("_" in result) {
+                result._.push(stripped);
+            } else {
+                result._ = [stripped];
+            }
+        } else if (/[=:]/.test(match)) {
             const [key, value] = match.split(/[:=]/, 2);
             const stripped = value.replace(/^["\s]|["\s]$/g, "");
 

--- a/packages/search/tests/parse-query.test.ts
+++ b/packages/search/tests/parse-query.test.ts
@@ -1,0 +1,39 @@
+import { parse_query } from "../src";
+
+describe("parse query", () => {
+    it("should recognize key:value", () => {
+        const q = parse_query("foo:bar");
+        expect(q.foo).toEqual(["bar"]);
+    });
+
+    it("should recognize key=value", () => {
+        const q = parse_query("foo=bar");
+        expect(q.foo).toEqual(["bar"]);
+    });
+
+    it("should recognize key:\"value with spaces\"", () => {
+        const q = parse_query("foo:\"bar baz\"");
+        expect(q.foo).toEqual(["bar baz"]);
+    });
+
+    it("should recognize key=\"value with spaces\"", () => {
+        const q = parse_query("foo=\"bar baz\"");
+        expect(q.foo).toEqual(["bar baz"]);
+    });
+
+    it("should collect wild value", () => {
+        const q = parse_query("foo bar baz");
+        expect(q._.sort()).toEqual(["foo", "bar", "baz"].sort());
+    });
+
+    it("should collect \"wild value with spaces\"", () => {
+        const q = parse_query("foo \"bar baz\"");
+        expect(q._.sort()).toEqual(["foo", "bar baz"].sort());
+    });
+
+    it("should escape `=` inside quotes", () => {
+        const q = parse_query("\"foo=bar\"");
+        expect(q).not.toHaveProperty("foo");
+        expect(q._).toEqual(["foo=bar"]);
+    });
+});


### PR DESCRIPTION
My first try to help UniCourse-TW/realm#39. Plan to add tests for app in the future.
BTW, how should the query package parse some special characters like `=`, `:` and `"` inside a quoted value?
I am not sure whether the current test is what we expected.
