### PR TITLE
fix(core): remove empty select from import api

### DIFF
--- a/src/api/manage/import.ts
+++ b/src/api/manage/import.ts
@@ -215,7 +215,6 @@ async function scoped_resolver(pack: CoursePack, scope: string): Promise<{
         ...down({
             include: {
                 courses: {
-                    select: {},
                     include: {
                         programs: {
                             select: { id: true, name: true }


### PR DESCRIPTION
fix #69 

Remove the useless empty `select` from query.